### PR TITLE
Fix extraneous Byte.zero

### DIFF
--- a/vc-current/Verif_strlib.v
+++ b/vc-current/Verif_strlib.v
@@ -603,11 +603,11 @@ Definition example_call_strcpy_spec :=
   PRE [  ]
     PROP ()
     PARAMS() GLOBALS (gv)
-    SEP (cstring Ews (Hello' ++ [Byte.zero]) (gv ___stringlit_1))
+    SEP (cstring Ews Hello' (gv ___stringlit_1))
   POST [ tint ]
     PROP ()
     RETURN (Vint (Int.repr (Z.of_N (Ascii.N_of_ascii "H"%char))))
-    SEP (cstring Ews (Hello' ++ [Byte.zero]) (gv ___stringlit_1)).
+    SEP (cstring Ews Hello' (gv ___stringlit_1)).
 
 Lemma body_example_call_strcpy: semax_body Vprog Gprog 
          f_example_call_strcpy example_call_strcpy_spec.


### PR DESCRIPTION
`cstring sh l p` already requires `l` does not contain `Byte.zero`.

The precondition is always invalid in the old specification, which makes the specification pointless.
The updated specification is correct and also provable.

(I see this repo not accepting PRs for code so please forward the change to sfdev, thank you!)