### PR TITLE
Adapt to https://github.com/rocq-prover/rocq/pull/17876

### DIFF
--- a/vfa-current/Trie.v
+++ b/vfa-current/Trie.v
@@ -169,10 +169,8 @@ Eval compute in print_in_binary ten.  (*  = [1; 0; 1; 0] *)
 (** Another way to see the "binary representation" is to make up
      postfix notation for [xI] and [xO], as follows *)
 
-Notation "p ~ 1" := (xI p)
- (at level 7, left associativity, format "p '~' '1'").
-Notation "p ~ 0" := (xO p)
- (at level 7, left associativity, format "p '~' '0'").
+Notation "p ~ 1" := (xI p).
+Notation "p ~ 0" := (xO p).
 
 Print ten. (* = xH~0~1~0 : positive *)
 


### PR DESCRIPTION
Adapt to https://github.com/rocq-prover/rocq/pull/17876

I have some vague remembrance that I shouldn't PR on this branch but we don't have any doc in https://github.com/rocq-prover/rocq/blob/336fc39aa6fdd327056a0839e172551641fb6c4d/dev/ci/ci-basic-overlay.sh#L456-L460

These notations are already reserved in Corelib and shouldn't be reserved again.

@bcpierce00, @liyishuai can I let you sort this out? Otherwise, no worries, I'll just temporarily disactivate SF in Rocq CI until this can be fixed.